### PR TITLE
Fix CMSmap on kali with local EXploitDB

### DIFF
--- a/cmsmap.py
+++ b/cmsmap.py
@@ -1922,7 +1922,10 @@ CrackingPasswords = False
 FullScan = False
 NoExploitdb = False
 dataPath = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
-exploitdbPath = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'exploitdb')
+if os.path.isdir(os.path.dirname('/usr/share/exploitdb/')):  # Fix for Kali
+    exploitdbPath = '/usr/share/exploitdb/'
+else:
+    exploitdbPath = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'exploitdb')
 exploitdbfilesPath = os.path.join(exploitdbPath, 'platforms')
 output = False
 threads = 5


### PR DESCRIPTION
In Kali the variable "exploitdbPath" isn't correct and it produces errors like:

[ERROR] Unable to extract Wordpress Themes Vulnerabilities from the local EXploitDB archive.
[ERROR] Unable to extract Wordpress Plugins Vulnerabilities from the local EXploitDB archive.

With this fix, it works as expected.

Thanks,